### PR TITLE
feat: add Vivaldi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Supported browsers on the respective OS:
       <td align=center>☑️</td>
       <td align=center>☑️</td>
     </tr>
+    <tr>
+      <td>Vivaldi</td>
+      <td align=center>☑️</td>
+      <td align=center>☑️</td>
+      <td align=center>☑️</td>
+    </tr>
   </tbody>
 </table>
 
@@ -133,7 +139,7 @@ Extension options:
 require('telescope').setup {
   extensions = {
     bookmarks = {
-      -- Available: 'brave', 'buku', 'chrome', 'chrome_beta', 'edge', 'safari', 'firefox'
+      -- Available: 'brave', 'buku', 'chrome', 'chrome_beta', 'edge', 'safari', 'firefox', 'vivaldi'
       selected_browser = 'brave',
 
       -- Either provide a shell command to open the URL

--- a/lua/telescope/_extensions/bookmarks.lua
+++ b/lua/telescope/_extensions/bookmarks.lua
@@ -29,6 +29,7 @@ local title = {
   edge = "Edge",
   firefox = "Firefox",
   safari = "Safari",
+  vivaldi = "Vivaldi",
 }
 
 ---Set the configuration state.

--- a/lua/telescope/_extensions/bookmarks/chrome.lua
+++ b/lua/telescope/_extensions/bookmarks/chrome.lua
@@ -40,6 +40,13 @@ local bookmarks_filepath = {
       "Default",
       "Bookmarks",
     },
+    vivaldi = {
+      "Library",
+      "Application Support",
+      "Vivaldi",
+      "Default",
+      "Bookmarks",
+    },
   },
   Linux = {
     brave = {
@@ -64,6 +71,12 @@ local bookmarks_filepath = {
     edge = {
       ".config",
       "microsoft-edge",
+      "Default",
+      "Bookmarks",
+    },
+    vivaldi = {
+      ".config",
+      "vivaldi",
       "Default",
       "Bookmarks",
     },
@@ -101,6 +114,14 @@ local bookmarks_filepath = {
       "Local",
       "Microsoft",
       "Edge",
+      "User Data",
+      "Default",
+      "Bookmarks",
+    },
+    vivaldi = {
+      "AppData",
+      "Local",
+      "Vivaldi",
       "User Data",
       "Default",
       "Bookmarks",

--- a/lua/telescope/_extensions/bookmarks/vivaldi.lua
+++ b/lua/telescope/_extensions/bookmarks/vivaldi.lua
@@ -1,0 +1,13 @@
+local chrome = require "telescope._extensions.bookmarks.chrome"
+
+local vivaldi = {}
+
+---Collect all the bookmarks for the Vivaldi browser.
+---NOTE: Vivaldi and Google Chrome uses the same underlying format to store bookmarks.
+---@param state ConfigState
+---@return Bookmark[]|nil
+function vivaldi.collect_bookmarks(state)
+  return chrome.collect_bookmarks(state)
+end
+
+return vivaldi


### PR DESCRIPTION
This adds support for [Vivaldi](https://vivaldi.com) -- another Chromium-based browser.